### PR TITLE
Allow `permission_required` to be iterable

### DIFF
--- a/django_orca/views.py
+++ b/django_orca/views.py
@@ -1,21 +1,26 @@
 from __future__ import annotations
+
 from collections.abc import Iterable
+from typing import Type
 
 from django.conf import settings
 from django.contrib.auth.mixins import AccessMixin
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.http import Http404
 
+from django_orca.roles import Role
+from django_orca.shortcuts import has_role
+
 
 class ObjectPermissionRequiredMixin(AccessMixin):
     """
     PermissionMixin
-    This mixin helps the class-based views
-    to secure them based in permissions.
+
+    This checks whether the accessor has the specified permission(s) on the referenced object
     """
 
     login_url = settings.LOGIN_URL
-    permission_required: str | Iterable[str] | None = None
+    permission_required: str | Iterable[str]
     return_404 = False
     return_403 = True
 
@@ -44,6 +49,49 @@ class ObjectPermissionRequiredMixin(AccessMixin):
     def has_permission(self):
         return self.request.user.has_perms(
             self.get_permission_required(), self.get_permission_object()
+        )
+
+    def dispatch(self, request, *args, **kwargs):
+        if not self.has_permission():
+            if self.return_404:
+                raise Http404
+            else:
+                raise PermissionDenied
+        else:
+            return super().dispatch(request, *args, **kwargs)
+
+
+class ObjectRoleRequiredMixin(AccessMixin):
+    login_url = settings.LOGIN_URL
+    role_required: Type[Role]
+    return_404 = False
+    return_403 = True
+
+    def get_role_required(self):
+        if self.role_required:
+            return self.role_required
+
+        raise ImproperlyConfigured("Provide a 'role_required' attribute.")
+
+    def get_permission_object(self):
+        if hasattr(self, "permission_object"):
+            return getattr(self, "permission_object")
+
+        elif hasattr(self, "object"):
+            if object := getattr(self, "object"):
+                return object
+
+        elif hasattr(self, "get_object"):
+            return getattr(self, "get_object")()
+
+        raise ImproperlyConfigured(
+            "Provide a 'permission_object' attribute or implement "
+            "a 'get_permission_object' method."
+        )
+
+    def has_permission(self):
+        return has_role(
+            self.request.user, self.role_required, self.get_permission_object()
         )
 
     def dispatch(self, request, *args, **kwargs):

--- a/django_orca/views.py
+++ b/django_orca/views.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from __future__ import annotations
+from collections.abc import Iterable
 
 from django.conf import settings
 from django.contrib.auth.mixins import AccessMixin
@@ -14,12 +15,12 @@ class ObjectPermissionRequiredMixin(AccessMixin):
     """
 
     login_url = settings.LOGIN_URL
-    permission_required: Optional[str] = None
+    permission_required: str | Iterable[str] | None = None
     return_404 = False
     return_403 = True
 
     def get_permission_required(self):
-        if self.permission_required != "":
+        if self.permission_required:
             return self.permission_required
 
         raise ImproperlyConfigured("Provide a 'permission_required' attribute.")
@@ -41,7 +42,7 @@ class ObjectPermissionRequiredMixin(AccessMixin):
         )
 
     def has_permission(self):
-        return self.request.user.has_perm(
+        return self.request.user.has_perms(
             self.get_permission_required(), self.get_permission_object()
         )
 

--- a/example_project/main/models.py
+++ b/example_project/main/models.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser
 from django.db import models
+from django.urls import reverse
 
 from django_orca.auth.mixins import UserRoleMixin
 
@@ -20,3 +21,6 @@ class Course(models.Model):
     name = models.CharField(max_length=256)
     enrolled_students = models.ManyToManyField(settings.AUTH_USER_MODEL)
     department = models.ForeignKey(Department, on_delete=models.CASCADE)
+
+    def get_absolute_url(self):
+        return reverse("course-detail", kwargs={"pk": self.pk})

--- a/example_project/main/views.py
+++ b/example_project/main/views.py
@@ -1,3 +1,10 @@
-# from django.shortcuts import render
+from django.views.generic.detail import DetailView
 
-# Create your views here.
+from django_orca.views import ObjectPermissionRequiredMixin
+
+from .models import Course
+
+
+class CourseDetailView(ObjectPermissionRequiredMixin, DetailView):
+    model = Course
+    permission_required = ["main.view_course", "main.change_course"]

--- a/example_project/main/views.py
+++ b/example_project/main/views.py
@@ -1,10 +1,16 @@
 from django.views.generic.detail import DetailView
 
-from django_orca.views import ObjectPermissionRequiredMixin
+from django_orca.views import ObjectPermissionRequiredMixin, ObjectRoleRequiredMixin
 
 from .models import Course
+from .roles import CourseOwner
 
 
 class CourseDetailView(ObjectPermissionRequiredMixin, DetailView):
     model = Course
     permission_required = ["main.view_course", "main.change_course"]
+
+
+class CourseOwnerDetailView(ObjectRoleRequiredMixin, DetailView):
+    model = Course
+    role_required = CourseOwner

--- a/example_project/settings.py
+++ b/example_project/settings.py
@@ -59,7 +59,7 @@ ROOT_URLCONF = "example_project.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [BASE_DIR / "example_project" / "templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [

--- a/example_project/urls.py
+++ b/example_project/urls.py
@@ -1,21 +1,9 @@
-"""example_project URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/4.1/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
 from django.contrib import admin
 from django.urls import path
 
+from example_project.main.views import CourseDetailView
+
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("course/<int:pk>", CourseDetailView.as_view(), name="course-detail"),
 ]

--- a/example_project/urls.py
+++ b/example_project/urls.py
@@ -1,9 +1,14 @@
 from django.contrib import admin
 from django.urls import path
 
-from example_project.main.views import CourseDetailView
+from example_project.main.views import CourseDetailView, CourseOwnerDetailView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("course/<int:pk>", CourseDetailView.as_view(), name="course-detail"),
+    path(
+        "course-owner/<int:pk>",
+        CourseOwnerDetailView.as_view(),
+        name="course-owner-detail",
+    ),
 ]


### PR DESCRIPTION
@joshuata What do you think about switching to [`has_perms`](https://github.com/django/django/blob/d54717118360e8679aa2bd0c5a1625f3e84712ba/django/contrib/auth/models.py#L313-L320), which accepts either `str` or `iterable`?